### PR TITLE
Use GLIBC_LIBRARY_PATH in GLIBC_LD_LINUX_SO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.4
 MAINTAINER Adam Dodman <adam.dodman@gmx.com>
 
 ENV UID=787 UNAME=plex GID=990 GNAME=media DESTDIR="/plex"
-ENV GLIBC_LIBRARY_PATH="$DESTDIR/lib" GLIBC_LD_LINUX_SO="/plex/lib/ld-linux-x86-64.so.2"
-ENV DEBS="libc6 libgcc1 libstdc++6 plexmediaserver"
+ENV GLIBC_LIBRARY_PATH="$DESTDIR/lib" DEBS="libc6 libgcc1 libstdc++6 plexmediaserver"
+ENV GLIBC_LD_LINUX_SO="$GLIBC_LIBRARY_PATH/ld-linux-x86-64.so.2"
 
 ADD start_pms.patch /tmp/start_pms.patch
 


### PR DESCRIPTION
Note that the environment variable has to be defined in a previous ENV command before it is available in the environment for use hence why I have swapped the last two over
